### PR TITLE
FEAT!: Add reasonPhrase from response

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -40,7 +40,11 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
             $body
         );
 
-        return $this->makeResponse($response->getBody()->getContents(), $response->getStatusCode());
+        return $this->makeResponse(
+            $response->getBody()->getContents(),
+            $response->getStatusCode(),
+            $response->getReasonPhrase()
+        );
     }
 
     /**
@@ -84,11 +88,13 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
     /**
      * @param string $data
      * @param int $statusCode
+     * @param string $reasonPhrase
      * @return ResponseInterface
      */
     abstract protected function makeResponse(
         string $data,
-        int $statusCode
+        int $statusCode,
+        string $reasonPhrase
     ): ResponseInterface;
 
     /**

--- a/src/Message/Request/FetchTransactionRequest.php
+++ b/src/Message/Request/FetchTransactionRequest.php
@@ -154,8 +154,8 @@ class FetchTransactionRequest extends AbstractRequest
     /**
      * @inheritDoc
      */
-    protected function makeResponse(string $data, int $statusCode): ResponseInterface
+    protected function makeResponse(string $data, int $statusCode, string $reasonPhrase): ResponseInterface
     {
-        return $this->response = new FetchTransactionResponse($this, $data, $statusCode);
+        return $this->response = new FetchTransactionResponse($this, $data, $statusCode, $reasonPhrase);
     }
 }

--- a/src/Message/Request/PurchaseRequest.php
+++ b/src/Message/Request/PurchaseRequest.php
@@ -275,10 +275,11 @@ class PurchaseRequest extends AbstractRequest
     /**
      * @param string $data
      * @param int $statusCode
+     * @param string $reasonPhrase
      * @return ResponseInterface
      */
-    protected function makeResponse(string $data, int $statusCode): ResponseInterface
+    protected function makeResponse(string $data, int $statusCode, string $reasonPhrase): ResponseInterface
     {
-        return $this->response = new PurchaseResponse($this, $data, $statusCode);
+        return $this->response = new PurchaseResponse($this, $data, $statusCode, $reasonPhrase);
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: `AbstractResponse` constructor now require reasonPhrase parameter

Now `getValueFromData` can accept dotted key to retrieve value recursive